### PR TITLE
 add password to privkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,5 @@ chorustool:
 	go build -ldflags "-X github.com/Baptist-Publication/chorus/src/client/main.version=`git rev-parse HEAD`" -o ./build/chorustool ./src/client
 test:
 	go test ./src/tools/state
-proto:
-	protoc --proto_path=$(GOPATH)/src --proto_path=src/chain/app/remote --go_out=plugins=grpc:src/chain/app/remote src/chain/app/remote/*.proto
-	protoc --proto_path=$(GOPATH)/src --proto_path=src/example/types --go_out=plugins=grpc:src/example/types src/example/types/*.proto
-	#protoc --proto_path=$(GOPATH)/src --proto_path=src/chain/node/protos --gofast_out=plugins=grpc:src/chain/node/protos src/chain/node/protos/*.proto
-	protoc --proto_path=src/types --go_out=src/types src/types/*.proto
+	go test ./src/tools
+	go test ./src/chain/node/

--- a/src/chain/cmd/init.go
+++ b/src/chain/cmd/init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/Baptist-Publication/angine"
+	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 )
 
 const (
@@ -33,10 +34,16 @@ var initCmd = &cobra.Command{
 	ValidArgs: []string{"chainid"},
 	Run: func(cmd *cobra.Command, args []string) {
 		chainID := cmd.Flag("chainid").Value.String()
+
+		pwd, err := libcrypto.InputPasswdForEncrypt()
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
 		// initCivilConfig(viper.GetString("config"))
 		angine.Initialize(&angine.Tunes{
 			Runtime: viper.GetString("runtime"),
-		}, chainID)
+		}, chainID, pwd)
 	},
 }
 

--- a/src/chain/cmd/root.go
+++ b/src/chain/cmd/root.go
@@ -63,29 +63,3 @@ func init() {
 	viper.BindPFlag("runtime", RootCmd.PersistentFlags().Lookup("runtime"))
 	viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 }
-
-// func initConfig() {
-// 	viper.SetEnvPrefix("civil")
-// 	viper.BindEnv(CONFPATH)
-// 	viper.AutomaticEnv() // read in environment variables that match
-
-// 	cfgFile := viper.GetString("config")
-// 	if cfgFile != "" {
-// 		viper.SetConfigFile(cfgFile)
-// 	} else {
-// 		viper.AddConfigPath(CivilPath())
-// 		viper.SetConfigName(".chorus")
-// 	}
-// 	// If a config file is found, read it in.
-// 	if err := viper.ReadInConfig(); err == nil {
-// 		fmt.Println("Using config file:", viper.ConfigFileUsed())
-// 	} else {
-
-// 	}
-// }
-
-// func initApp() {
-// 	//	node.Apps["ikhofi"] = func(l *zap.Logger, c *viper.Viper, p crypto.PrivKey) (node.Application, error) {
-// 	//		return ikhofi.NewAVMApp(ikhofi.InitIkhofiConfig(c.GetString("db_dir"), c))
-// 	//	}
-// }

--- a/src/chain/cmd/run.go
+++ b/src/chain/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 	"github.com/Baptist-Publication/chorus/src/chain/log"
 	"github.com/Baptist-Publication/chorus/src/chain/node"
 )
@@ -43,9 +44,14 @@ var runCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+		pwd, err := libcrypto.InputPasswdForDecrypt()
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
 		viper.Set("log_path", logpath)
 		logger := log.Initialize(env, path.Join(logpath, "node.output.log"), path.Join(logpath, "node.err.log"))
-		node.RunNode(logger, viper.GetViper())
+		node.RunNode(logger, viper.GetViper(), pwd)
 	},
 }
 

--- a/src/chain/cmd/run.go
+++ b/src/chain/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	ac "github.com/Baptist-Publication/angine/config"
 	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 	"github.com/Baptist-Publication/chorus/src/chain/log"
 	"github.com/Baptist-Publication/chorus/src/chain/node"
@@ -35,8 +36,13 @@ var runCmd = &cobra.Command{
 
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		env := viper.GetString("environment")
-		logpath := viper.GetString("log_path")
+		aConf := ac.GetConfig(viper.GetString("runtime"))
+		for k, v := range viper.AllSettings() {
+			aConf.Set(k, v)
+		}
+
+		env := aConf.GetString("environment")
+		logpath := aConf.GetString("log_path")
 		if logpath == "" {
 			var err error
 			if logpath, err = os.Getwd(); err != nil {
@@ -49,9 +55,10 @@ var runCmd = &cobra.Command{
 			cmd.Println(err)
 			return
 		}
-		viper.Set("log_path", logpath)
+
+		aConf.Set("log_path", logpath)
 		logger := log.Initialize(env, path.Join(logpath, "node.output.log"), path.Join(logpath, "node.err.log"))
-		node.RunNode(logger, viper.GetViper(), pwd)
+		node.RunNode(logger, aConf, pwd)
 	},
 }
 

--- a/src/chain/cmd/show.go
+++ b/src/chain/cmd/show.go
@@ -14,11 +14,14 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"github.com/Baptist-Publication/angine"
+	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 )
 
 var showCmd = &cobra.Command{
@@ -41,7 +44,12 @@ func init() {
 			Long:  "",
 			Args:  cobra.NoArgs,
 			Run: func(cmd *cobra.Command, args []string) {
-				ang := angine.NewAngine(zap.NewNop(), &angine.Tunes{Runtime: viper.GetString("runtime")})
+				pwd, err := libcrypto.InputPasswdForDecrypt()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				ang := angine.NewAngine(zap.NewNop(), &angine.Tunes{Runtime: viper.GetString("runtime")}, pwd)
 				cmd.Println(ang.PrivValidator().PubKey)
 			},
 		},

--- a/src/chain/config/reset.go
+++ b/src/chain/config/reset.go
@@ -14,10 +14,10 @@ const (
 	SHARDSDIR = "shards"
 )
 
-func GetConfig(root string) (conf *viper.Viper) {
+func GetConfig(root string, pwd []byte) (conf *viper.Viper) {
 	var err error
 	runtime := acfg.RuntimeDir(root)
-	acfg.InitRuntime(runtime, conf.GetString("chain_id"))
+	acfg.InitRuntime(runtime, conf.GetString("chain_id"), pwd)
 
 	conf = viper.New()
 	conf.SetEnvPrefix("ANGINE")

--- a/src/chain/node/accstate_test.go
+++ b/src/chain/node/accstate_test.go
@@ -6,9 +6,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/tendermint/tmlibs/db"
 	cmn "github.com/Baptist-Publication/chorus-module/lib/go-common"
 	"github.com/Baptist-Publication/chorus-module/lib/go-crypto"
+	"github.com/tendermint/tmlibs/db"
 )
 
 func getAccState() *AccState {
@@ -29,25 +29,41 @@ func getPowerState() *PowerState {
 	return NewPowerState(accDB)
 }
 
-func randomPubkey() *crypto.PubKeyEd25519 {
-	sk1 := crypto.GenPrivKeyEd25519()
+func randomPubkey() (*crypto.PubKeyEd25519, error) {
+	sk1, err := crypto.GenPrivKeyEd25519(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer sk1.Destroy()
 	pk2 := sk1.PubKey()
 	pk2bs := pk2.(*crypto.PubKeyEd25519)
 
-	return pk2bs
+	return pk2bs, nil
 }
 
 func randomBig(max uint64) *big.Int {
 	return new(big.Int).SetUint64(rand.Uint64() % max)
 }
 
+func _checkErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestIterateAccountState(t *testing.T) {
 	as := getAccState()
 
-	k1 := randomPubkey()
-	k2 := randomPubkey()
-	k3 := randomPubkey()
-	k4 := randomPubkey()
+	var k1, k2, k3, k4 *crypto.PubKeyEd25519
+	var err error
+	k1, err = randomPubkey()
+	_checkErr(t, err)
+	k2, err = randomPubkey()
+	_checkErr(t, err)
+	k3, err = randomPubkey()
+	_checkErr(t, err)
+	k4, err = randomPubkey()
+	_checkErr(t, err)
 
 	as.AddBalance(k1, new(big.Int).SetUint64(10))
 	as.AddBalance(k2, new(big.Int).SetUint64(20))
@@ -75,10 +91,16 @@ func TestIterateAccountState(t *testing.T) {
 func TestIteratePowerState(t *testing.T) {
 	ps := getPowerState()
 
-	k1 := randomPubkey()
-	k2 := randomPubkey()
-	k3 := randomPubkey()
-	k4 := randomPubkey()
+	var k1, k2, k3, k4 *crypto.PubKeyEd25519
+	var err error
+	k1, err = randomPubkey()
+	_checkErr(t, err)
+	k2, err = randomPubkey()
+	_checkErr(t, err)
+	k3, err = randomPubkey()
+	_checkErr(t, err)
+	k4, err = randomPubkey()
+	_checkErr(t, err)
 
 	ps.CreatePower(k1[:], new(big.Int).SetUint64(10), 1)
 	ps.CreatePower(k2[:], new(big.Int).SetUint64(20), 1)
@@ -112,7 +134,8 @@ func TestElection(t *testing.T) {
 	}
 
 	for i := 0; i < 50; i++ {
-		k := randomPubkey()
+		k, err := randomPubkey()
+		_checkErr(t, err)
 		p := new(big.Int).SetUint64(uint64(10 + i*10))
 		ps.CreatePower(k[:], p, 1)
 		as.CreateAccount(k[:], Big0)

--- a/src/chain/node/metropolis.go
+++ b/src/chain/node/metropolis.go
@@ -500,7 +500,7 @@ func (met *Metropolis) createOrgNode(tx *OrgTx) (*OrgNode, error) {
 	resChan := make(chan *OrgNode, 1)
 	go func(c chan<- *OrgNode) {
 		applog := log.Initialize(met.config.GetString("environment"), path.Join(conf.GetString("log_path"), tx.ChainID, "output.log"), path.Join(conf.GetString("log_path"), tx.ChainID, "err.log"))
-		n := NewOrgNode(applog, tx.App, conf, met)
+		n := NewOrgNode(applog, conf, tx.App, met)
 		if n == nil {
 			met.logger.Error("startOrgNode failed", zap.Error(err))
 			c <- nil

--- a/src/chain/node/metropolis_event.go
+++ b/src/chain/node/metropolis_event.go
@@ -100,7 +100,7 @@ func (met *Metropolis) PublishEvent(chainID string, block *agtypes.BlockCache, d
 
 		if sendNotification && len(notifications) > 0 {
 			for _, n := range notifications {
-				n.Signature, _ = cvtools.TxSign(n, &privkey)
+				n.Signature, _ = cvtools.TxSign(n, privkey)
 				txBytes, _ := cvtools.TxToBytes(n)
 				if err := met.BroadcastTx(agtypes.WrapTx(EventNotificationTag, txBytes)); err != nil {
 					return err
@@ -245,7 +245,7 @@ func (met *Metropolis) handleEventConnection(conn net.Conn) {
 		Msg:      emsg,
 		Time:     time.Now(),
 	}
-	if _, err := cvtools.TxSign(emt, &privkey); err != nil {
+	if _, err := cvtools.TxSign(emt, privkey); err != nil {
 		met.logger.Error("fail to sign EventMsgTx", zap.Error(err))
 		return
 	}

--- a/src/chain/node/metropolis_executetx.go
+++ b/src/chain/node/metropolis_executetx.go
@@ -280,7 +280,7 @@ func (met *Metropolis) executeOrgTx(tx *OrgTx) (err error) {
 
 	defer func() {
 		if cancelOnError && err != nil {
-			met.sendOrgCancel(tx, &pubkey, txHash)
+			met.sendOrgCancel(tx, pubkey, txHash)
 		}
 	}()
 
@@ -325,7 +325,7 @@ func (met *Metropolis) executeOrgTx(tx *OrgTx) (err error) {
 		return fmt.Errorf("unimplemented")
 	}
 
-	met.sendOrgConfirm(tx, &pubkey, txHash, node)
+	met.sendOrgConfirm(tx, pubkey, txHash, node)
 	return nil
 }
 
@@ -423,7 +423,7 @@ func (met *Metropolis) executeEventRequestTx(tx *EventRequestTx, height def.INT,
 			Data:     tx.SourceHash,
 		}
 
-		if _, err := cvtools.TxSign(ctx, &privkey); err != nil {
+		if _, err := cvtools.TxSign(ctx, privkey); err != nil {
 			return errors.Wrap(err, "[executeEventRequestTx]")
 		}
 		txBytes, _ := cvtools.TxToBytes(ctx)
@@ -485,7 +485,7 @@ func (met *Metropolis) executeCoSiInitTx(tx *CoSiInitTx, height def.INT) error {
 			Data:       append(tx.Data, []byte("|<>|"+etx.Listener)...),
 		}
 
-		if _, err := cvtools.TxSign(cositx, &privkey); err != nil {
+		if _, err := cvtools.TxSign(cositx, privkey); err != nil {
 			return errors.Wrap(err, "[executeCoSiInitTx]")
 		}
 		txBytes, _ := cvtools.TxToBytes(cositx)

--- a/src/chain/node/metropolis_restore.go
+++ b/src/chain/node/metropolis_restore.go
@@ -43,7 +43,7 @@ func (met *Metropolis) restoreOrgConfirm(txBytes []byte) {
 func (met *Metropolis) restoreOrg(txBytes []byte) {
 	var (
 		err    error
-		pubkey crypto.PubKeyEd25519
+		pubkey *crypto.PubKeyEd25519
 		txHash []byte
 		node   *OrgNode
 

--- a/src/chain/node/node.go
+++ b/src/chain/node/node.go
@@ -47,14 +47,14 @@ func AppExists(name string) (yes bool) {
 	return
 }
 
-func NewNode(logger *zap.Logger, conf *viper.Viper) *Node {
+func NewNode(logger *zap.Logger, conf *viper.Viper, pwd []byte) *Node {
 	aConf := ac.GetConfig(conf.GetString("runtime"))
 	for k, v := range conf.AllSettings() {
 		aConf.Set(k, v)
 	}
 
 	metropolis := NewMetropolis(logger, aConf)
-	metroAngine := angine.NewAngine(logger, &angine.Tunes{Conf: aConf})
+	metroAngine := angine.NewAngine(logger, &angine.Tunes{Conf: aConf}, pwd)
 	tune := metroAngine.Tune
 	if err := metroAngine.ConnectApp(metropolis); err != nil {
 		cmn.PanicCrisis(err)
@@ -93,8 +93,8 @@ func NewNode(logger *zap.Logger, conf *viper.Viper) *Node {
 	return node
 }
 
-func RunNode(logger *zap.Logger, config *viper.Viper) {
-	node := NewNode(logger, config)
+func RunNode(logger *zap.Logger, config *viper.Viper, pwd []byte) {
+	node := NewNode(logger, config, pwd)
 	if err := node.Start(); err != nil {
 		cmn.Exit(cmn.Fmt("Failed to start node: %v", err))
 	}

--- a/src/chain/node/node.go
+++ b/src/chain/node/node.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/Baptist-Publication/angine"
-	ac "github.com/Baptist-Publication/angine/config"
 	"github.com/Baptist-Publication/angine/types"
 	cmn "github.com/Baptist-Publication/chorus-module/lib/go-common"
 	"github.com/Baptist-Publication/chorus-module/lib/go-crypto"
@@ -47,12 +46,7 @@ func AppExists(name string) (yes bool) {
 	return
 }
 
-func NewNode(logger *zap.Logger, conf *viper.Viper, pwd []byte) *Node {
-	aConf := ac.GetConfig(conf.GetString("runtime"))
-	for k, v := range conf.AllSettings() {
-		aConf.Set(k, v)
-	}
-
+func NewNode(logger *zap.Logger, aConf *viper.Viper, pwd []byte) *Node {
 	metropolis := NewMetropolis(logger, aConf)
 	metroAngine := angine.NewAngine(logger, &angine.Tunes{Conf: aConf}, pwd)
 	tune := metroAngine.Tune

--- a/src/chain/node/orgnode.go
+++ b/src/chain/node/orgnode.go
@@ -33,7 +33,7 @@ type OrgNode struct {
 	GenesisDoc  *agtypes.GenesisDoc
 }
 
-func NewOrgNode(logger *zap.Logger, appName string, conf *viper.Viper, metro *Metropolis) *OrgNode {
+func NewOrgNode(logger *zap.Logger, conf *viper.Viper, appName string, metro *Metropolis) *OrgNode {
 	defer func() {
 		// in case App constructor calls panic
 		if err := recover(); err != nil {
@@ -45,8 +45,9 @@ func NewOrgNode(logger *zap.Logger, appName string, conf *viper.Viper, metro *Me
 		return nil
 	}
 
+	var pwd []byte
 	tune := &angine.Tunes{Conf: conf}
-	ang := angine.NewAngine(logger, tune)
+	ang := angine.NewAngine(logger, tune, pwd)
 	if ang == nil {
 		logger.Error("fail to new Angine")
 		return nil
@@ -119,17 +120,13 @@ func (o *OrgNode) GetEngine() Engine {
 	return o.Angine
 }
 
-func (o *OrgNode) GetPublicKey() (r crypto.PubKeyEd25519, b bool) {
-	var pr *crypto.PubKeyEd25519
-	pr, b = o.Angine.PrivValidator().GetPubKey().(*crypto.PubKeyEd25519)
-	r = *pr
+func (o *OrgNode) GetPublicKey() (r *crypto.PubKeyEd25519, b bool) {
+	r, b = o.Angine.PrivValidator().GetPubKey().(*crypto.PubKeyEd25519)
 	return
 }
 
-func (o *OrgNode) GetPrivateKey() (r crypto.PrivKeyEd25519, b bool) {
-	var pr *crypto.PrivKeyEd25519
-	pr, b = o.Angine.PrivValidator().GetPrivKey().(*crypto.PrivKeyEd25519)
-	r = *pr
+func (o *OrgNode) GetPrivateKey() (r *crypto.PrivKeyEd25519, b bool) {
+	r, b = o.Angine.PrivValidator().GetPrivKey().(*crypto.PrivKeyEd25519)
 	return
 }
 

--- a/src/chain/node/types.go
+++ b/src/chain/node/types.go
@@ -93,8 +93,8 @@ type (
 		Publisher
 
 		IsValidator() bool
-		GetPublicKey() (crypto.PubKeyEd25519, bool)
-		GetPrivateKey() (crypto.PrivKeyEd25519, bool)
+		GetPublicKey() (*crypto.PubKeyEd25519, bool)
+		GetPrivateKey() (*crypto.PrivKeyEd25519, bool)
 		GetChainID() string
 		GetEngine() Engine
 		BroadcastTxSuperior([]byte) error
@@ -329,7 +329,7 @@ func (app *EventAppBase) ConfirmEvent(tx *EventNotificationTx) error {
 		Time:     time.Now(),
 	}
 	ftx.TxHash, _ = tools.TxHash(tx)
-	if _, err := tools.TxSign(ftx, &privkey); err != nil {
+	if _, err := tools.TxSign(ftx, privkey); err != nil {
 		return errors.Wrap(err, "[EventAppBase ConfirmEvent]")
 	}
 	txBytes, _ := tools.TxToBytes(ftx)
@@ -421,7 +421,7 @@ func (app *EventAppBase) ExecuteTx(bs []byte, validators *agtypes.ValidatorSet) 
 			SignData:    cositx.Data,
 			CoSignature: cosignature,
 		}
-		tools.TxSign(estx, &privkey)
+		tools.TxSign(estx, privkey)
 		txBytes, _ := tools.TxToBytes(estx)
 		fmt.Println("broadcast subscription")
 		if err := app.core.BroadcastTxSuperior(agtypes.WrapTx(EventSubscribeTag, txBytes)); err != nil {

--- a/src/client/commands/accounts.go
+++ b/src/client/commands/accounts.go
@@ -1,10 +1,8 @@
 package commands
 
 import (
-	"encoding/hex"
 	"fmt"
 
-	gcommon "github.com/Baptist-Publication/chorus-module/lib/go-common"
 	"github.com/Baptist-Publication/chorus-module/lib/go-crypto"
 	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 	"gopkg.in/urfave/cli.v1"
@@ -66,23 +64,12 @@ func generatePrivPubAddr(ctx *cli.Context) error {
 }
 
 func calculatePrivPubAddr(ctx *cli.Context) error {
-	if !ctx.IsSet("privkey") {
-		return cli.NewExitError("private key is required", -1)
-	}
-	var pwd []byte
-	if ctx.IsSet(anntoolFlags.passwd.GetName()) {
-		pwd = []byte(ctx.String(anntoolFlags.passwd.GetName()))
-	}
-
-	skBs, err := hex.DecodeString(gcommon.SanitizeHex(ctx.String("privkey")))
+	privKey, err := ParsePrivkey(ctx)
 	if err != nil {
-		return cli.NewExitError(err.Error(), -1)
+		return cli.NewExitError(err.Error(), 127)
 	}
-
-	var sk crypto.PrivKeyEd25519
-	sk.InitAndDecrypt(skBs, pwd)
-
-	pk := sk.PubKey().(*crypto.PubKeyEd25519)
+	defer privKey.Destroy()
+	pk := privKey.PubKey().(*crypto.PubKeyEd25519)
 	addr := pk.Address()
 
 	fmt.Printf("pubkey : %X\n", pk[:])

--- a/src/client/commands/accounts.go
+++ b/src/client/commands/accounts.go
@@ -6,6 +6,7 @@ import (
 
 	gcommon "github.com/Baptist-Publication/chorus-module/lib/go-common"
 	"github.com/Baptist-Publication/chorus-module/lib/go-crypto"
+	libcrypto "github.com/Baptist-Publication/chorus-module/xlib/crypto"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -21,6 +22,9 @@ var (
 				Action:   generatePrivPubAddr,
 				Usage:    "generate new private-pub key pair",
 				Category: "Account",
+				Flags: []cli.Flag{
+					anntoolFlags.passwd,
+				},
 			},
 			{
 				Name:     "cal",
@@ -29,6 +33,7 @@ var (
 				Category: "Account",
 				Flags: []cli.Flag{
 					anntoolFlags.privkey,
+					anntoolFlags.passwd,
 				},
 			},
 		},
@@ -36,11 +41,26 @@ var (
 )
 
 func generatePrivPubAddr(ctx *cli.Context) error {
-	sk := crypto.GenPrivKeyEd25519()
+	var pwd []byte
+	var err error
+	if ctx.IsSet(anntoolFlags.passwd.GetName()) {
+		pwd = []byte(ctx.String(anntoolFlags.passwd.GetName()))
+	} else {
+		pwd, err = libcrypto.InputPasswdForEncrypt()
+		if err != nil {
+			return nil
+		}
+	}
+	sk, err := crypto.GenPrivKeyEd25519(pwd)
+	if err != nil {
+		return err
+	}
+	defer sk.Destroy()
 	pk := sk.PubKey().(*crypto.PubKeyEd25519)
 
-	fmt.Printf("privkey: %X\n", sk[:])
-	fmt.Printf("pubkey: %X\n", pk[:])
+	fmt.Printf("ori-privkey: %X\n", sk.KeyBytes())
+	fmt.Printf("privkey: %X\n", sk.Bytes())
+	fmt.Printf("pubkey: %X\n", pk.Bytes())
 
 	return nil
 }
@@ -49,6 +69,10 @@ func calculatePrivPubAddr(ctx *cli.Context) error {
 	if !ctx.IsSet("privkey") {
 		return cli.NewExitError("private key is required", -1)
 	}
+	var pwd []byte
+	if ctx.IsSet(anntoolFlags.passwd.GetName()) {
+		pwd = []byte(ctx.String(anntoolFlags.passwd.GetName()))
+	}
 
 	skBs, err := hex.DecodeString(gcommon.SanitizeHex(ctx.String("privkey")))
 	if err != nil {
@@ -56,7 +80,7 @@ func calculatePrivPubAddr(ctx *cli.Context) error {
 	}
 
 	var sk crypto.PrivKeyEd25519
-	copy(sk[:], skBs)
+	sk.InitAndDecrypt(skBs, pwd)
 
 	pk := sk.PubKey().(*crypto.PubKeyEd25519)
 	addr := pk.Address()

--- a/src/client/commands/flags.go
+++ b/src/client/commands/flags.go
@@ -26,6 +26,7 @@ type AnntoolFlags struct {
 	rpc,
 	chainid,
 	to,
+	passwd,
 	codeHash cli.Flag
 }
 
@@ -99,6 +100,10 @@ var anntoolFlags = AnntoolFlags{
 	},
 	codeHash: cli.StringFlag{
 		Name:  "code_hash",
+		Value: "",
+	},
+	passwd: cli.StringFlag{
+		Name:  "pwd",
 		Value: "",
 	},
 }

--- a/src/client/commands/transactions.go
+++ b/src/client/commands/transactions.go
@@ -10,8 +10,7 @@ import (
 
 	"gopkg.in/urfave/cli.v1"
 
-	"github.com/Baptist-Publication/angine/types"
-	//anginetypes "github.com/Baptist-Publication/angine/types"
+	agtypes "github.com/Baptist-Publication/angine/types"
 	gcommon "github.com/Baptist-Publication/chorus-module/lib/go-common"
 	"github.com/Baptist-Publication/chorus-module/lib/go-crypto"
 	"github.com/Baptist-Publication/chorus-module/lib/go-merkle"
@@ -68,9 +67,9 @@ var (
 	}
 )
 
-func (act Transactions) jsonRPC(chainID string, p []byte) (*types.RPCResult, error) {
+func (act Transactions) jsonRPC(chainID string, p []byte) (*agtypes.RPCResult, error) {
 	clt := rpcclient.NewClientJSONRPC(logger, commons.QueryServer)
-	tmResult := new(types.RPCResult)
+	tmResult := new(agtypes.RPCResult)
 	_, err := clt.Call("broadcast_tx_sync", []interface{}{chainID, p}, tmResult)
 	if err != nil {
 		return nil, err
@@ -95,11 +94,11 @@ func (act Transactions) TransferBalance(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	privKey := crypto.PrivKeyEd25519{}
-	copy(privKey[:], privBytes)
+
+	privKey := crypto.DecryptSlcToEd25519(privBytes, nil)
 	frompubkey := privKey.PubKey().(*crypto.PubKeyEd25519)
 
-	topubkey32, err := types.StringTo32byte(to)
+	topubkey32, err := agtypes.StringTo32byte(to)
 	if err != nil {
 		return err
 	}
@@ -124,12 +123,12 @@ func (act Transactions) TransferBalance(ctx *cli.Context) error {
 		tx.Fee = big.NewInt(0)
 	}
 
-	tx.Signature, _ = tools.TxSign(tx, &privKey)
+	tx.Signature, _ = tools.TxSign(tx, privKey)
 	txbytes, err := tools.TxToBytes(tx)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 127)
 	}
-	txbytes = types.WrapTx(node.EcoTransferTag, txbytes)
+	txbytes = agtypes.WrapTx(node.EcoTransferTag, txbytes)
 
 	_, err = act.jsonRPC(chainID, txbytes)
 	if err != nil {
@@ -160,8 +159,8 @@ func (act Transactions) Mortgage(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	privKey := crypto.PrivKeyEd25519{}
-	copy(privKey[:], privBytes)
+
+	privKey := crypto.DecryptSlcToEd25519(privBytes, nil)
 	frompubkey := privKey.PubKey().(*crypto.PubKeyEd25519)
 
 	value := ctx.Int64("value")
@@ -181,12 +180,12 @@ func (act Transactions) Mortgage(ctx *cli.Context) error {
 		tx.Fee = big.NewInt(0)
 	}
 
-	tx.Signature, _ = tools.TxSign(tx, &privKey)
+	tx.Signature, _ = tools.TxSign(tx, privKey)
 	txbytes, err := tools.TxToBytes(tx)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 127)
 	}
-	txbytes = types.WrapTx(node.EcoMortgageTag, txbytes)
+	txbytes = agtypes.WrapTx(node.EcoMortgageTag, txbytes)
 
 	_, err = act.jsonRPC(chainID, txbytes)
 	if err != nil {
@@ -217,8 +216,7 @@ func (act Transactions) Redemption(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	privKey := crypto.PrivKeyEd25519{}
-	copy(privKey[:], privBytes)
+	privKey := crypto.DecryptSlcToEd25519(privBytes, nil)
 	frompubkey := privKey.PubKey().(*crypto.PubKeyEd25519)
 
 	value := ctx.Int64("value")
@@ -238,12 +236,12 @@ func (act Transactions) Redemption(ctx *cli.Context) error {
 		tx.Fee = big.NewInt(0)
 	}
 
-	tx.Signature, _ = tools.TxSign(tx, &privKey)
+	tx.Signature, _ = tools.TxSign(tx, privKey)
 	txbytes, err := tools.TxToBytes(tx)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 127)
 	}
-	txbytes = types.WrapTx(node.EcoRedemptionTag, txbytes)
+	txbytes = agtypes.WrapTx(node.EcoRedemptionTag, txbytes)
 
 	_, err = act.jsonRPC(chainID, txbytes)
 	if err != nil {

--- a/src/tools/golua_test.go
+++ b/src/tools/golua_test.go
@@ -3,22 +3,28 @@ package tools
 import "testing"
 
 const (
+	codeOrgC = `
+	function main(params)
+		params = {
+			["params1"] = {1,2} ,      
+			["params2"] = "Hello World"
+		}
+		return params;
+	end
+	`
 	codeOrgA = `                         
-	print("in A:"..ent_params["Params1"][1]+ent_params["Params1"][2])  
-	for i = 1,  #(ent_params["Params1"]) do             
-	        print(i..","..ent_params["Params1"][i])     
-	end                                  
+	function main(params)
+		for i = 1, #(params["params1"]) do
+			print(i..","..params["params1"][i])
+		end
+		return nil
+	end
 	`
 	codeOrgB = `                         
-	print("in B:"..ent_params["Params2"])               
-	`
-	globalVarName = "ent_params"
-
-	codeOrgC = `
-	ret_params= {                
-        	["params1"] = {1,2} ,      
-        	["params2"] = "Hello World"
-	}                        
+	function main(params)
+		print("in B:"..params["params2"])               
+		return nil
+	end
 	`
 )
 
@@ -35,11 +41,13 @@ func TestGoLua(t *testing.T) {
 		t.Error("ret_param err:", ret)
 	}
 
+	L = NewLuaState()
 	_, err = ExecLuaWithParam(L, codeOrgA, ret)
 	if err != nil {
 		t.Error("codeOrgA", err, ret)
 	}
 
+	L = NewLuaState()
 	_, err = ExecLuaWithParam(L, codeOrgB, ret)
 	if err != nil {
 		t.Error("codeOrgB", err, ret)


### PR DESCRIPTION
- add password to privkey.
  - So when generate a privkeyEd25519,we should call Decrypt with param pwd.
  - `chorus init` would ask u to input password(len <= 16).
  - Use `chorus resetpwd` to re-encrypt priv_validator.json,
  - cmds in `chorustool` whitch need privkey before, now need u to inpush password if u give a encrypted privkey.
- fix:err in reading node's param log_path from config.
  - node's command line params would cover angine's params, but angine sets the default settings,but the default value of "log_path" is set at node.